### PR TITLE
Check for JENKINS_DIRECT_CONNECTION value

### DIFF
--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -23,7 +23,7 @@
 [CmdletBinding()]
 Param(
     $Cmd = '', # this must be specified explicitly
-    $Url = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_URL)) { throw ("Url is required") } else { '' } ),
+    $Url = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_URL) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_DIRECT_CONNECTION)) { throw ("Url is required") } else { '' } ),
     [Parameter(Position=0)]$Secret = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_SECRET)) { throw ("Secret is required") } else { '' } ),
     [Parameter(Position=1)]$Name = $( if([System.String]::IsNullOrWhiteSpace($Cmd) -and [System.String]::IsNullOrWhiteSpace($env:JENKINS_AGENT_NAME)) { throw ("Name is required") } else { '' } ),
     $Tunnel = '',


### PR DESCRIPTION
This fixes jenkinsci/docker-agent#590 by only requiring `JENKINS_URL` have a value when `JENKINS_DIRECT_CONNECTION` is not set as well.